### PR TITLE
Add Table Validation

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -65,6 +65,7 @@ const enabledNodeTypes = validation('enabledNodeTypes', Joi.array().items(Joi.st
   'unordered-list',
   'hr',
   'blockquote',
+  'table',
   'embedded-entry-block',
   'embedded-asset-block',
   'hyperlink',

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -203,6 +203,7 @@ describe('payload validation', function () {
           .name('Chapter')
           .type('RichText')
           .validations([
+            { enabledNodeTypes: ['table'] },
             { nodes: {
               'embedded-entry-block': [{ size: { max: 4 } }],
               'embedded-entry-inline': [{ size: { max: 4 } }],


### PR DESCRIPTION
## Summary

Currently exporting a Rich Text field includes the `table` validation, importing it with this tool does not work.

Adding necessary validation for it to work.